### PR TITLE
Fix video format sorting function to fix Aethercast FTBFS

### DIFF
--- a/libwds/common/video_format.cpp
+++ b/libwds/common/video_format.cpp
@@ -152,10 +152,10 @@ std::pair<unsigned, unsigned> get_resolution(const H264VideoFormat& format) {
 
 bool video_format_sort_func(const H264VideoFormat& a, const H264VideoFormat& b) {
   if (get_quality_info(a).weight != get_quality_info(b).weight)
-    return get_quality_info(a).weight < get_quality_info(b).weight;
+    return get_quality_info(a).weight > get_quality_info(b).weight;
   if (a.profile != b.profile)
-    return a.profile < b.profile;
-  return a.level < b.level;
+    return a.profile > b.profile;
+  return a.level > b.level;
 }
 
 template <typename RREnum>


### PR DESCRIPTION
Due to a regression in wds, there's a test in Aethercast that make sure wds sorts video format correctly. Ubuntu patched it with a distribution patch. However, our import, being in Debian-native mode, doesn't take that patch into account. This causes Aethercast to FTBFS.

This PR brings in the fixing commit by merging. This very same commit is already in a pull request to upstream [1]. Doing this helps reduce the chance of merge conflict in the future.

[1] https://github.com/intel/wds/pull/191